### PR TITLE
Update desktop CTA styling and show selected timeslots

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -373,6 +373,23 @@ body {
   border-radius: 9999px;
 }
 
+/* Make desktop FutureVersion CTAs (date/time) match mobile chip styling */
+@media (min-width: 1024px) {
+  .future-cta-card .cta-button {
+    background: #f1f5f9;
+    color: #0f172a;
+    border: 1px solid #e5e7eb;
+    box-shadow: none;
+  }
+
+  .future-cta-card .cta-button.cta-button--secondary {
+    background: #f1f5f9;
+    color: #0f172a;
+    border: 1px solid #e5e7eb;
+    box-shadow: none;
+  }
+}
+
 /* Mobile inline controls between title/location and description */
 .future-inline-controls {
   display: grid;
@@ -1392,6 +1409,12 @@ textarea.form-input,
   font-weight: 500;
   color: #1e293b;
   font-size: 15px;
+}
+
+.date-summary-time {
+  color: #64748b;
+  font-size: 14px;
+  margin-top: 4px;
 }
 
 .favorite-btn {

--- a/src/pages/Checkout.jsx
+++ b/src/pages/Checkout.jsx
@@ -255,7 +255,12 @@ export default function Checkout() {
               <div className="dates-summary-list">
                 {currentRequest.dates.map((date) => (
                   <div key={date.iso} className="date-summary-item">
-                    <span className="date-summary-text">{date.formatted}</span>
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
+                      <span className="date-summary-text">{date.formatted}</span>
+                      {date.time && (
+                        <div className="date-summary-time">Selected time: {date.time}</div>
+                      )}
+                    </div>
                     {(!anyFavourited || date.isFavourite) && (
                       <button
                         type="button"


### PR DESCRIPTION
Update desktop CTA styling to match mobile chips and display selected timeslots on the checkout page.

---
<a href="https://cursor.com/background-agent?bcId=bc-3108aae4-7759-4ef6-be65-4bd16c69d01d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3108aae4-7759-4ef6-be65-4bd16c69d01d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

