### PR TITLE
Adjust date and time selector modals for viewport

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,6 +11,15 @@ body {
   line-height: 1.5;
 }
 
+/* Theme variables */
+:root {
+  --primary: #0f8b7c; /* new green */
+  --primary-contrast: #ffffff;
+  --primary-shadow-10: rgba(15, 139, 124, 0.10);
+  --primary-shadow-20: rgba(15, 139, 124, 0.20);
+  --primary-shadow-25: rgba(15, 139, 124, 0.25);
+}
+
 .app {
   max-width: 100%;
   width: 100%;
@@ -169,7 +178,7 @@ body {
 
 .extend {
   font-size: 15px;
-  color: #0ea5a4;
+  color: var(--primary);
   text-decoration: underline;
   cursor: pointer;
 }
@@ -259,15 +268,15 @@ body {
 
 .cta-button {
   width: 100%;
-  background: #0ea5a4;
-  color: #ffffff;
+  background: var(--primary);
+  color: var(--primary-contrast);
   border: none;
   padding: 16px 20px;
   border-radius: 12px;
   font-size: 16px;
   font-weight: 800;
   cursor: pointer;
-  box-shadow: 0 6px 14px rgba(14, 165, 164, 0.25);
+  box-shadow: 0 6px 14px var(--primary-shadow-25);
 }
 
 .cta-button[disabled],
@@ -280,8 +289,8 @@ body {
 /* Secondary CTA style: white fill, green text and border */
 .cta-button--secondary {
   background: #ffffff;
-  color: #0ea5a4;
-  border: 2px solid #0ea5a4;
+  color: var(--primary);
+  border: 2px solid var(--primary);
   box-shadow: none;
 }
 
@@ -568,10 +577,10 @@ body {
   white-space: nowrap;
 }
 .timeslot-pill.selected {
-  background: #0ea5a4;
+  background: var(--primary);
   color: #ffffff;
-  border-color: #0ea5a4;
-  box-shadow: 0 4px 10px rgba(14, 165, 164, 0.2);
+  border-color: var(--primary);
+  box-shadow: 0 4px 10px var(--primary-shadow-20);
 }
 
 /* Location picker */
@@ -745,9 +754,9 @@ body {
 }
 
 .calendar-day.selected {
-  background: #0ea5a4; /* CTA color */
+  background: var(--primary); /* CTA color */
   color: #ffffff;
-  box-shadow: 0 4px 10px rgba(14, 165, 164, 0.2);
+  box-shadow: 0 4px 10px var(--primary-shadow-20);
 }
 
 /* Disabled/unavailable day (e.g., Saturdays) */
@@ -1216,8 +1225,8 @@ textarea.form-input,
 
 .form-input:focus {
   outline: none;
-  border-color: #0ea5a4;
-  box-shadow: 0 0 0 3px rgba(14, 165, 164, 0.1);
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-shadow-10);
 }
 
 .form-input.error {

--- a/src/components/TimeslotModal.jsx
+++ b/src/components/TimeslotModal.jsx
@@ -96,14 +96,37 @@ export default function TimeslotModal({ isOpen, onClose, anchorRef }) {
     function updatePosition() {
       if (!anchorRef.current) return;
       const rect = anchorRef.current.getBoundingClientRect();
-      const desiredTop = rect.bottom + 8; // small offset
-      const RIGHT_MARGIN = 48;
-      const BOTTOM_MARGIN = 128; // leave space for CTA area
-      const availableRight = window.innerWidth - rect.left;
-      const maxWidth = Math.min(520, availableRight - RIGHT_MARGIN);
-      const width = Math.max(380, maxWidth);
-      const maxHeight = Math.max(240, window.innerHeight - desiredTop - BOTTOM_MARGIN);
-      setPosition({ top: desiredTop, left: rect.left, width, maxHeight });
+
+      const LEFT_MARGIN = 24;
+      const RIGHT_MARGIN = 24;
+      const TOP_MARGIN = 16;
+      const BOTTOM_MARGIN = 24;
+
+      // Timeslot popover should be slightly narrower and shorter than calendar
+      const IDEAL_WIDTH = 560;
+      const MIN_WIDTH = 420;
+      const SAFE_MIN_WIDTH = 360;
+
+      const alignRight = Math.min(rect.right, window.innerWidth - RIGHT_MARGIN);
+      const maxWidthFromViewport = alignRight - LEFT_MARGIN;
+      const width = Math.max(
+        SAFE_MIN_WIDTH,
+        Math.min(IDEAL_WIDTH, Math.max(MIN_WIDTH, maxWidthFromViewport))
+      );
+      const left = Math.max(LEFT_MARGIN, alignRight - width);
+
+      // Flip above if needed and anchor the popover to the top of the CTA if near the top edge
+      const spaceBelow = window.innerHeight - rect.bottom - BOTTOM_MARGIN;
+      const spaceAbove = rect.top - TOP_MARGIN;
+      const preferBelow = spaceBelow >= spaceAbove;
+      const OFFSET = 8;
+      const desiredTop = preferBelow ? rect.bottom + OFFSET : Math.max(TOP_MARGIN, rect.top - OFFSET);
+      const maxHeight = preferBelow
+        ? Math.max(220, spaceBelow)
+        : Math.max(220, spaceAbove);
+      const top = preferBelow ? desiredTop : Math.max(TOP_MARGIN, rect.top - maxHeight - OFFSET);
+
+      setPosition({ top, left, width, maxHeight });
     }
 
     updatePosition();


### PR DESCRIPTION
Update date and time selector modals for viewport-safe positioning on desktop and change the primary theme color to green.

---
<a href="https://cursor.com/background-agent?bcId=bc-dfa77ee5-f481-4668-a791-130b79e23341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dfa77ee5-f481-4668-a791-130b79e23341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

