### PR TITLE
Update icons and adjust selector display

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1566,7 +1566,7 @@ textarea.form-input,
   border: 1px solid #e5e7eb;
   border-radius: 16px; /* more rounded corners */
   box-shadow: 0 12px 28px rgba(0,0,0,0.12);
-  overflow: auto; /* allow scroll when constrained by viewport */
+  overflow: visible; /* allow content to spill past viewport */
   padding: 16px 16px 20px 16px; /* extra padding for CTA space */
 }
 

--- a/src/components/CalendarPopover.jsx
+++ b/src/components/CalendarPopover.jsx
@@ -227,7 +227,7 @@ export default function CalendarPopover({ anchorRef, onClose, selectedLocation, 
         <div
           ref={popoverRef}
           className="cta-popover"
-          style={{ top: `${position.top}px`, left: `${position.left}px`, width: `${position.width}px`, maxHeight: `${position.maxHeight}px` }}
+          style={{ top: `${position.top}px`, left: `${position.left}px`, width: `${position.width}px` }}
           role="dialog"
           aria-modal="false"
         >

--- a/src/components/DateTimeLocationPicker.jsx
+++ b/src/components/DateTimeLocationPicker.jsx
@@ -163,7 +163,7 @@ const DateTimeLocationPicker = forwardRef((props, ref) => {
   return (
     <div className="location-picker">
       <div className="location-panel">
-        <div className="location-title"><span aria-hidden>📍</span> Choose Location</div>
+        <div className="location-title"><span className="chip-icon chip-icon--pin" aria-hidden="true"></span> Choose Location</div>
         <label htmlFor="location-button" className="location-label">Location</label>
         <div className="location-select-wrapper" ref={locationWrapperRef}>
           <button
@@ -204,7 +204,7 @@ const DateTimeLocationPicker = forwardRef((props, ref) => {
 
       <div className="calendar-panel">
         <div className="calendar-title-section">
-          <div className="location-title"><span aria-hidden>📅</span> Choose Dates</div>
+          <div className="location-title"><span className="chip-icon chip-icon--calendar" aria-hidden="true"></span> Choose Dates</div>
         </div>
         <div className="date-picker">
           <label className="location-label" htmlFor="date-toggle">Select date</label>

--- a/src/components/TimeslotModal.jsx
+++ b/src/components/TimeslotModal.jsx
@@ -232,7 +232,7 @@ export default function TimeslotModal({ isOpen, onClose, anchorRef }) {
     <div
       ref={popoverRef}
       className="cta-popover"
-      style={{ top: `${position.top}px`, left: `${position.left}px`, width: `${position.width}px`, maxHeight: `${position.maxHeight}px` }}
+      style={{ top: `${position.top}px`, left: `${position.left}px`, width: `${position.width}px` }}
       role="dialog"
       aria-modal="false"
     >

--- a/src/pages/Checkout.jsx
+++ b/src/pages/Checkout.jsx
@@ -243,12 +243,12 @@ export default function Checkout() {
           
           <div className="summary-section">
             <div className="summary-location">
-              <span className="summary-label">📍 Location:</span>
+              <span className="summary-label"><span className="chip-icon chip-icon--pin" aria-hidden="true"></span> Location:</span>
               <span className="summary-value">{currentRequest.location}</span>
             </div>
             
             <div className="summary-dates">
-              <span className="summary-label">📅 Selected Dates:</span>
+              <span className="summary-label"><span className="chip-icon chip-icon--calendar" aria-hidden="true"></span> Selected Dates:</span>
               <p className="description" style={{ marginTop: 8 }}>
                 Mark one Top Preference so the supplier knows which date to prioritise.
               </p>

--- a/src/pages/Confirmation.jsx
+++ b/src/pages/Confirmation.jsx
@@ -50,11 +50,11 @@ export default function Confirmation() {
           <div className="confirmation-left">
             <div className="summary-section">
               <div className="summary-location">
-                <span className="summary-label">📍 Location:</span>
+                <span className="summary-label"><span className="chip-icon chip-icon--pin" aria-hidden="true"></span> Location:</span>
                 <span className="summary-value">{location}</span>
               </div>
               <div className="summary-dates">
-                <span className="summary-label">📅 Requested dates:</span>
+                <span className="summary-label"><span className="chip-icon chip-icon--calendar" aria-hidden="true"></span> Requested dates:</span>
                 <div className="dates-summary-list">
                   {requestedDates.length > 0 ? (
                     requestedDates.map(date => (

--- a/src/pages/FutureVersion.jsx
+++ b/src/pages/FutureVersion.jsx
@@ -69,7 +69,7 @@ export default function FutureVersion() {
             <div className="product-id">118107722</div>
             <h1 className="title">{PRODUCT_TITLE}</h1>
             <div className="location">
-              📍 The Aspinall Foundation, Nr Ashford Kent, Lympne Hythe, CT21 4PD
+              <span className="chip-icon chip-icon--pin" aria-hidden="true"></span> The Aspinall Foundation, Nr Ashford Kent, Lympne Hythe, CT21 4PD
             </div>
             <div className="validity">
               <span className="use-by">Use by 19th Aug 2026</span>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -61,7 +61,7 @@ export default function Home() {
             <div className="product-id">118107722</div>
             <h1 className="title">{PRODUCT_TITLE}</h1>
             <div className="location">
-              📍 The Aspinall Foundation, Nr Ashford Kent, Lympne Hythe, CT21 4PD
+              <span className="chip-icon chip-icon--pin" aria-hidden="true"></span> The Aspinall Foundation, Nr Ashford Kent, Lympne Hythe, CT21 4PD
             </div>
             <div className="validity">
               <span className="use-by">Use by 19th Aug 2026</span>
@@ -182,7 +182,7 @@ export default function Home() {
 
               <div className="booking-info">
                 <div className="booking-info-row">
-                  <span className="booking-info-icon" aria-hidden="true">📍</span>
+                  <span className="booking-info-icon" aria-hidden="true"><span className="chip-icon chip-icon--pin" aria-hidden="true"></span></span>
                   <span>Port Lympne, Kent, England</span>
                 </div>
                 <div className="booking-info-row">

--- a/src/pages/RequestToBook.jsx
+++ b/src/pages/RequestToBook.jsx
@@ -84,7 +84,7 @@ export default function RequestToBook() {
         <div className="product-id">118107722</div>
         <h1 className="title">{PRODUCT_TITLE}</h1>
         <div className="location">
-          📍 The Aspinall Foundation, Nr Ashford Kent, Lympne Hythe, CT21 4PD
+          <span className="chip-icon chip-icon--pin" aria-hidden="true"></span> The Aspinall Foundation, Nr Ashford Kent, Lympne Hythe, CT21 4PD
         </div>
         <div className="validity">
           <span className="use-by">Use by 19th Aug 2026</span>


### PR DESCRIPTION
Replace old colorful calendar and location pin icons with minimalist versions and remove viewport-aware cropping from desktop date/timeslot selectors.

---
<a href="https://cursor.com/background-agent?bcId=bc-773a8654-a623-4ab4-b07e-8c60f31a1a8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-773a8654-a623-4ab4-b07e-8c60f31a1a8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

