### PR TITLE
Add checkout logo to assets and pages

### DIFF
--- a/public/assets/buyagift-by-moonpig.svg
+++ b/public/assets/buyagift-by-moonpig.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 406 112" role="img" aria-label="buyagift by moonpig logo">
+  <defs>
+    <linearGradient id="pink" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ff9ec1"/>
+      <stop offset="100%" stop-color="#ffb6d0"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Left teal block -->
+  <rect x="4" y="8" rx="12" ry="12" width="268" height="96" fill="#0f8b84"/>
+
+  <!-- Right pink block -->
+  <rect x="276" y="8" rx="12" ry="12" width="126" height="96" fill="url(#pink)"/>
+
+  <!-- buyagift text -->
+  <g fill="#ffffff" font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif" font-weight="700">
+    <text x="24" y="58" font-size="40" letter-spacing="0.5">buya</text>
+    <text x="158" y="58" font-size="40" letter-spacing="0.5">gift</text>
+  </g>
+
+  <!-- simple gift bow accent above the i -->
+  <g transform="translate(196,26)">
+    <circle cx="0" cy="0" r="4" fill="#f2b200"/>
+    <path d="M-10,-2 C-6,-8, -2,-8, 0,-2" fill="none" stroke="#f2b200" stroke-width="3" stroke-linecap="round"/>
+    <path d="M10,-2 C6,-8, 2,-8, 0,-2" fill="none" stroke="#f2b200" stroke-width="3" stroke-linecap="round"/>
+  </g>
+
+  <!-- by moonpig text -->
+  <g fill="#ffffff" font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif" font-weight="700">
+    <text x="296" y="50" font-size="26">by</text>
+    <text x="296" y="82" font-size="28">moonpig</text>
+  </g>
+</svg>

--- a/src/components/BrandLogo.jsx
+++ b/src/components/BrandLogo.jsx
@@ -3,7 +3,11 @@ import React from "react";
 export default function BrandLogo() {
   return (
     <div aria-label="Brand" role="img" style={{ display: 'inline-block' }}>
-      <img src="/assets/buyagift-by-moonpig.png" alt="buyagift by moonpig" className="brand-logo" />
+      <img
+        src="/assets/buyagift-by-moonpig.svg"
+        alt="buyagift by moonpig"
+        className="brand-logo"
+      />
     </div>
   );
 }


### PR DESCRIPTION
Add the 'buyagift by moonpig' SVG logo and update `BrandLogo.jsx` to display it on checkout, confirmation, and supplier pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e99fe1b-2fe1-478b-a2eb-3ddf0580a622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e99fe1b-2fe1-478b-a2eb-3ddf0580a622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

