### PR TITLE
Update logo to local png on checkout pages

### DIFF
--- a/src/components/BrandLogo.jsx
+++ b/src/components/BrandLogo.jsx
@@ -4,9 +4,15 @@ export default function BrandLogo() {
   return (
     <div aria-label="Brand" role="img" style={{ display: 'inline-block' }}>
       <img
-        src="/assets/buyagift-by-moonpig.svg"
+        src="/assets/buyagift-by-moonpig.png"
         alt="buyagift by moonpig"
         className="brand-logo"
+        onError={(e) => {
+          const img = e.currentTarget;
+          if (img.dataset.fallback === 'true') return;
+          img.dataset.fallback = 'true';
+          img.src = '/assets/buyagift-by-moonpig.svg';
+        }}
       />
     </div>
   );


### PR DESCRIPTION
Update `BrandLogo.jsx` to use a PNG logo with a fallback to the existing SVG.

This change ensures that the checkout, confirmation, and supplier pages display the new PNG logo, while providing a graceful fallback if the PNG file is not present.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c7d7b05-9358-4b30-bbd1-8621d5296028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c7d7b05-9358-4b30-bbd1-8621d5296028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

