### PR TITLE
Create autoaccept page from root

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ export default function App() {
   return (
     <Routes>
       <Route path="/" element={<FutureVersion />} />
+      <Route path="/autoaccept" element={<FutureVersion />} />
       <Route path="/future-version" element={<FutureVersion />} />
       <Route path="/legacy" element={<Home />} />
       <Route path="/request-to-book" element={<RequestToBook />} />


### PR DESCRIPTION
Add `/autoaccept` route to mirror the root page's functionality and UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-f22e335d-93b6-49bd-bf0d-2af80ff430ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f22e335d-93b6-49bd-bf0d-2af80ff430ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

