### PR TITLE
Unify date and time selection for autoaccept

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1635,3 +1635,38 @@ textarea.form-input,
   max-height: none;
   overflow: visible;
 }
+
+/* Time wheel styles */
+.time-wheel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+.wheel-column {
+  height: 144px; /* 4 visible items (36px each) */
+  width: 72px;
+  overflow-y: auto;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #ffffff;
+  scroll-behavior: smooth;
+}
+.wheel-item {
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 400; /* Droid Sans regular */
+  font-family: 'Droid Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+}
+.wheel-item.selected {
+  background: #0f766e;
+  color: #ffffff;
+}
+.wheel-separator {
+  font-weight: 700;
+  color: #0f172a;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1644,6 +1644,12 @@ textarea.form-input,
   gap: 8px;
   margin-top: 12px;
 }
+.hour-stepper { display: grid; grid-template-areas: 'up' 'display' 'down' 'grid'; justify-items: center; gap: 8px; }
+.hour-arrow { appearance: none; border: 1px solid #e5e7eb; background: #ffffff; padding: 6px 10px; border-radius: 8px; cursor: pointer; }
+.hour-display { font-size: 22px; font-weight: 800; padding: 4px 8px; }
+.hour-quick-grid { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 6px; max-width: 320px; }
+.hour-chip { padding: 6px 8px; border: 1px solid #e5e7eb; border-radius: 8px; background: #ffffff; cursor: pointer; }
+.hour-chip.selected { background: #0f766e; color: #ffffff; border-color: #0f766e; }
 .wheel-column {
   height: 144px; /* 4 visible items (36px each) */
   width: 72px;
@@ -1670,3 +1676,6 @@ textarea.form-input,
   font-weight: 700;
   color: #0f172a;
 }
+.minute-toggle { display: grid; grid-template-columns: 1fr 1fr; width: 144px; border: 1px solid #e5e7eb; border-radius: 12px; overflow: hidden; }
+.minute-half { appearance: none; border: none; background: #ffffff; padding: 10px 0; cursor: pointer; font-size: 16px; font-weight: 600; }
+.minute-half.selected { background: #0f766e; color: #ffffff; }

--- a/src/components/CalendarPopover.jsx
+++ b/src/components/CalendarPopover.jsx
@@ -313,7 +313,7 @@ export default function CalendarPopover({ anchorRef, onClose, selectedLocation, 
           aria-modal="false"
         >
           <div className="calendar open">
-            <div className="calendar-caption">{isAutoAccept ? 'Select a date' : 'Select dates (you can choose up to 5)'}</div>
+            <div className="calendar-caption">{isAutoAccept ? (hasTimeslotParam ? 'Select a date and time' : 'Select a date') : 'Select dates (you can choose up to 5)'}</div>
             <div className="calendar-desktop-container">
               <div className="calendar-month">
                 <div className="calendar-header">
@@ -408,17 +408,72 @@ export default function CalendarPopover({ anchorRef, onClose, selectedLocation, 
                 Please select a maximum of 5 dates
               </div>
             )}
-            {!isAutoAccept && (
-              <div className="booking-cta">
-                <button
-                  type="button"
-                  className="cta-button cta-button--pill"
-                  onClick={handleProceedClick}
+            {(isAutoAccept && hasTimeslotParam) && (
+              <div className="time-wheel" aria-label="Select time">
+                <div
+                  className="wheel-column"
+                  role="listbox"
+                  aria-label="Hours"
+                  tabIndex={0}
+                  ref={hoursRef}
+                  onKeyDown={(e) => {
+                    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+                      e.preventDefault();
+                      const delta = e.key === 'ArrowUp' ? -1 : 1;
+                      const idx = hourOptions.indexOf(selectedHour);
+                      const nextIdx = Math.max(0, Math.min(hourOptions.length - 1, idx + delta));
+                      setSelectedHour(hourOptions[nextIdx]);
+                    }
+                  }}
+                  onScroll={(e) => {
+                    const idx = Math.round(e.currentTarget.scrollTop / 36);
+                    const bounded = Math.max(0, Math.min(hourOptions.length - 1, idx));
+                    setSelectedHour(hourOptions[bounded]);
+                  }}
                 >
-                  {ctaLabel}
-                </button>
+                  {hourOptions.map(h => (
+                    <div key={h} role="option" aria-selected={selectedHour === h} className={`wheel-item${selectedHour === h ? ' selected' : ''}`}>{String(h).padStart(2, '0')}</div>
+                  ))}
+                </div>
+                <div className="wheel-separator">:</div>
+                <div
+                  className="wheel-column"
+                  role="listbox"
+                  aria-label="Minutes"
+                  tabIndex={0}
+                  ref={minutesRef}
+                  onKeyDown={(e) => {
+                    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+                      e.preventDefault();
+                      const delta = e.key === 'ArrowUp' ? -1 : 1;
+                      const idx = minuteOptions.indexOf(selectedMinute);
+                      const nextIdx = Math.max(0, Math.min(minuteOptions.length - 1, idx + delta));
+                      setSelectedMinute(minuteOptions[nextIdx]);
+                    }
+                  }}
+                  onScroll={(e) => {
+                    const idx = Math.round(e.currentTarget.scrollTop / 36);
+                    const bounded = Math.max(0, Math.min(minuteOptions.length - 1, idx));
+                    setSelectedMinute(minuteOptions[bounded]);
+                  }}
+                >
+                  {minuteOptions.map(m => (
+                    <div key={m} role="option" aria-selected={selectedMinute === m} className={`wheel-item${selectedMinute === m ? ' selected' : ''}`}>{String(m).padStart(2, '0')}</div>
+                  ))}
+                </div>
               </div>
             )}
+            <div className="booking-cta">
+              <button
+                type="button"
+                className="cta-button cta-button--pill"
+                onClick={handleProceedClick}
+                disabled={isAutoAccept ? selectedDates.size === 0 : false}
+                aria-disabled={isAutoAccept ? selectedDates.size === 0 : false}
+              >
+                {ctaLabel}
+              </button>
+            </div>
           </div>
         </div>
       ) : (
@@ -485,17 +540,72 @@ export default function CalendarPopover({ anchorRef, onClose, selectedLocation, 
                     Please select a maximum of 5 dates
                   </div>
                 )}
-                {!isAutoAccept && (
-                  <div className="booking-cta">
-                    <button
-                      type="button"
-                      className="cta-button cta-button--pill"
-                      onClick={handleProceedClick}
+                {(isAutoAccept && hasTimeslotParam) && (
+                  <div className="time-wheel" aria-label="Select time">
+                    <div
+                      className="wheel-column"
+                      role="listbox"
+                      aria-label="Hours"
+                      tabIndex={0}
+                      ref={hoursRef}
+                      onKeyDown={(e) => {
+                        if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+                          e.preventDefault();
+                          const delta = e.key === 'ArrowUp' ? -1 : 1;
+                          const idx = hourOptions.indexOf(selectedHour);
+                          const nextIdx = Math.max(0, Math.min(hourOptions.length - 1, idx + delta));
+                          setSelectedHour(hourOptions[nextIdx]);
+                        }
+                      }}
+                      onScroll={(e) => {
+                        const idx = Math.round(e.currentTarget.scrollTop / 36);
+                        const bounded = Math.max(0, Math.min(hourOptions.length - 1, idx));
+                        setSelectedHour(hourOptions[bounded]);
+                      }}
                     >
-                      {ctaLabel}
-                    </button>
+                      {hourOptions.map(h => (
+                        <div key={h} role="option" aria-selected={selectedHour === h} className={`wheel-item${selectedHour === h ? ' selected' : ''}`}>{String(h).padStart(2, '0')}</div>
+                      ))}
+                    </div>
+                    <div className="wheel-separator">:</div>
+                    <div
+                      className="wheel-column"
+                      role="listbox"
+                      aria-label="Minutes"
+                      tabIndex={0}
+                      ref={minutesRef}
+                      onKeyDown={(e) => {
+                        if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+                          e.preventDefault();
+                          const delta = e.key === 'ArrowUp' ? -1 : 1;
+                          const idx = minuteOptions.indexOf(selectedMinute);
+                          const nextIdx = Math.max(0, Math.min(minuteOptions.length - 1, idx + delta));
+                          setSelectedMinute(minuteOptions[nextIdx]);
+                        }
+                      }}
+                      onScroll={(e) => {
+                        const idx = Math.round(e.currentTarget.scrollTop / 36);
+                        const bounded = Math.max(0, Math.min(minuteOptions.length - 1, idx));
+                        setSelectedMinute(minuteOptions[bounded]);
+                      }}
+                    >
+                      {minuteOptions.map(m => (
+                        <div key={m} role="option" aria-selected={selectedMinute === m} className={`wheel-item${selectedMinute === m ? ' selected' : ''}`}>{String(m).padStart(2, '0')}</div>
+                      ))}
+                    </div>
                   </div>
                 )}
+                <div className="booking-cta">
+                  <button
+                    type="button"
+                    className="cta-button cta-button--pill"
+                    onClick={handleProceedClick}
+                    disabled={isAutoAccept ? selectedDates.size === 0 : false}
+                    aria-disabled={isAutoAccept ? selectedDates.size === 0 : false}
+                  >
+                    {ctaLabel}
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/CalendarPopover.jsx
+++ b/src/components/CalendarPopover.jsx
@@ -27,6 +27,22 @@ export default function CalendarPopover({ anchorRef, onClose, selectedLocation, 
   const hoursRef = useRef(null);
   const minutesRef = useRef(null);
 
+  function incrementHour(delta) {
+    const idx = hourOptions.indexOf(selectedHour);
+    const nextIdx = Math.max(0, Math.min(hourOptions.length - 1, idx + delta));
+    const nextHour = hourOptions[nextIdx];
+    setSelectedHour(nextHour);
+    if (hoursRef.current) {
+      hoursRef.current.scrollTo({ top: nextIdx * 36, behavior: 'smooth' });
+    }
+  }
+  function onMinuteKeyDown(e) {
+    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedMinute((m) => (m === 0 ? 30 : 0));
+    }
+  }
+
   function addMonths(baseDate, delta) {
     return new Date(baseDate.getFullYear(), baseDate.getMonth() + delta, 1);
   }

--- a/src/pages/FutureVersion.jsx
+++ b/src/pages/FutureVersion.jsx
@@ -136,7 +136,7 @@ export default function FutureVersion() {
                 {/* Unified Date & Time pill (autoaccept) */}
                 <button
                   type="button"
-                  className="chip-button"
+                  className="chip-button chip-button--full"
                   ref={ctaMobileRef}
                   onClick={() => setIsCalendarOpen(true)}
                   aria-haspopup="dialog"

--- a/src/pages/FutureVersion.jsx
+++ b/src/pages/FutureVersion.jsx
@@ -133,7 +133,7 @@ export default function FutureVersion() {
                   <span>{selectedLocation ? selectedLocation : "Choose location"}</span>
                 </button>
 
-                {/* Dates pill */}
+                {/* Unified Date & Time pill (autoaccept) */}
                 <button
                   type="button"
                   className="chip-button"
@@ -143,19 +143,9 @@ export default function FutureVersion() {
                   aria-expanded={isCalendarOpen}
                 >
                   <span className="chip-icon chip-icon--calendar" aria-hidden="true"></span>
-                  <span>Select date</span>
+                  <span>{isAutoAccept ? 'Select date and time' : 'Select date'}</span>
                 </button>
-
-                {/* Times pill */}
-                <button
-                  type="button"
-                  className="chip-button"
-                  ref={timeslotMobileRef}
-                  onClick={() => setIsTimeslotOpen(true)}
-                >
-                  <span className="chip-icon chip-icon--clock" aria-hidden="true"></span>
-                  <span>Select time</span>
-                </button>
+                {/* Separate time pill removed for unified flow */}
               </div>
               <div className="divider"></div>
             </div>
@@ -221,19 +211,8 @@ export default function FutureVersion() {
                   aria-expanded={isCalendarOpen}
                 >
                   <span className="chip-icon" aria-hidden="true"></span>
-                  Date
+                  {isAutoAccept ? 'Select date and time' : 'Date'}
                 </button>
-                {hasTimeslotParam && (
-                  <button
-                    className="cta-button cta-button--secondary cta-button--pill cta-button--timeslot"
-                    type="button"
-                    onClick={() => setIsTimeslotOpen(true)}
-                    ref={timeslotDesktopRef}
-                  >
-                    <span className="chip-icon" aria-hidden="true"></span>
-                    Time
-                  </button>
-                )}
               </div>
               {/* Desktop proceed CTA for both flows; keep below and full-width */}
               <button


### PR DESCRIPTION
Combine autoaccept date and time selection into a single modal to streamline the user experience and add a direct checkout CTA.

Previously, autoaccept flows with timeslots required users to select a date, then navigate to a separate timeslot modal. This PR unifies these steps into a single calendar modal, embedding a time scroll wheel when the `?timeslot` parameter is present, and directly proceeds to checkout, improving flow efficiency.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4cb5e66-fa68-4fc9-a9f1-c33f4d6b1a4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4cb5e66-fa68-4fc9-a9f1-c33f4d6b1a4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

