### PR TITLE
Create generic autoaccept product page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ export default function App() {
     <Routes>
       <Route path="/" element={<FutureVersion />} />
       <Route path="/autoaccept" element={<FutureVersion />} />
+      <Route path="/product/autoaccept" element={<FutureVersion />} />
       <Route path="/future-version" element={<FutureVersion />} />
       <Route path="/legacy" element={<Home />} />
       <Route path="/request-to-book" element={<RequestToBook />} />

--- a/src/components/CalendarPopover.jsx
+++ b/src/components/CalendarPopover.jsx
@@ -7,7 +7,8 @@ export default function CalendarPopover({ anchorRef, onClose, selectedLocation, 
   const [position, setPosition] = useState({ top: 0, left: 0, width: 0, maxHeight: 0 });
   const navigate = useNavigate();
   const { pathname, search } = useLocation();
-  const isAutoAccept = pathname === '/autoaccept';
+  const isAutoAccept = pathname === '/autoaccept' || pathname === '/product/autoaccept';
+  const isProductAutoAccept = pathname === '/product/autoaccept';
   const hasTimeslotParam = new URLSearchParams(search).has('timeslot');
 
   const [currentMonth, setCurrentMonth] = useState(() => {
@@ -119,7 +120,7 @@ export default function CalendarPopover({ anchorRef, onClose, selectedLocation, 
           time: hasTimeslotParam ? getSelectedTimeLabel() : undefined,
         }];
         const draft = {
-          location: selectedLocation || 'Port Lympne Kent',
+          location: selectedLocation || (isProductAutoAccept ? 'Multiple venues across the UK' : 'Port Lympne Kent'),
           dates,
           timestamp: new Date().toISOString(),
           source: 'autoaccept',
@@ -173,7 +174,7 @@ export default function CalendarPopover({ anchorRef, onClose, selectedLocation, 
         time: (isAutoAccept && hasTimeslotParam) ? getSelectedTimeLabel() : undefined,
       }));
       const draft = {
-        location: selectedLocation || 'Port Lympne Kent',
+        location: selectedLocation || (isProductAutoAccept ? 'Multiple venues across the UK' : 'Port Lympne Kent'),
         dates,
         timestamp: new Date().toISOString(),
         source: isAutoAccept ? 'autoaccept' : 'regular',
@@ -261,7 +262,7 @@ export default function CalendarPopover({ anchorRef, onClose, selectedLocation, 
         time: (isAutoAccept && hasTimeslotParam) ? getSelectedTimeLabel() : undefined,
       }));
       const draft = {
-        location: selectedLocation || "Port Lympne Kent",
+        location: selectedLocation || (isProductAutoAccept ? 'Multiple venues across the UK' : "Port Lympne Kent"),
         dates,
         timestamp: new Date().toISOString(),
         source: isAutoAccept ? 'autoaccept' : 'regular',
@@ -283,7 +284,7 @@ export default function CalendarPopover({ anchorRef, onClose, selectedLocation, 
         time: (isAutoAccept && hasTimeslotParam) ? getSelectedTimeLabel() : undefined,
       }));
       const draft = {
-        location: selectedLocation || "Port Lympne Kent",
+        location: selectedLocation || (isProductAutoAccept ? 'Multiple venues across the UK' : "Port Lympne Kent"),
         dates,
         timestamp: new Date().toISOString(),
         source: isAutoAccept ? 'autoaccept' : 'regular',

--- a/src/components/TimeslotModal.jsx
+++ b/src/components/TimeslotModal.jsx
@@ -4,7 +4,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 export default function TimeslotModal({ isOpen, onClose, anchorRef }) {
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const isAutoAccept = pathname === '/autoaccept';
+  const isAutoAccept = pathname === '/autoaccept' || pathname === '/product/autoaccept';
   const [dates, setDates] = useState([]); // [{ iso, formatted }]
   const [selectedTimesByIso, setSelectedTimesByIso] = useState({}); // { [iso]: 'HH:MM' }
   const popoverRef = useRef(null);

--- a/src/pages/FutureVersion.jsx
+++ b/src/pages/FutureVersion.jsx
@@ -27,7 +27,7 @@ export default function FutureVersion() {
   const locationChipCardRef = useRef(null);
   const { search, pathname } = useLocation();
   const hasTimeslotParam = new URLSearchParams(search).has('timeslot');
-  const isAutoAccept = pathname === '/autoaccept';
+  const isAutoAccept = pathname === '/autoaccept' || pathname === '/product/autoaccept';
 
   useEffect(() => {
     const mql = window.matchMedia('(min-width: 1024px)');
@@ -114,9 +114,9 @@ export default function FutureVersion() {
         <div className="product-layout">
           <div className="product-main">
             <div className="product-id">118107722</div>
-            <h1 className="title">{PRODUCT_TITLE}</h1>
+            <h1 className="title">{isAutoAccept && pathname === '/product/autoaccept' ? 'Unforgettable Experience for Two' : PRODUCT_TITLE}</h1>
             <div className="location">
-              <span className="chip-icon chip-icon--pin" aria-hidden="true"></span> The Aspinall Foundation, Nr Ashford Kent, Lympne Hythe, CT21 4PD
+              <span className="chip-icon chip-icon--pin" aria-hidden="true"></span> {isAutoAccept && pathname === '/product/autoaccept' ? 'Multiple venues across the UK' : 'The Aspinall Foundation, Nr Ashford Kent, Lympne Hythe, CT21 4PD'}
             </div>
             <div className="validity">
               <span className="use-by">Use by 19th Aug 2026</span>
@@ -174,32 +174,60 @@ export default function FutureVersion() {
             </div>
 
             <h2 className="section-title">About the experience</h2>
-            <p className="description">
-              Explore the vast 600-acre expanse of Port Lympne Reserve and its historic landscape,
-              then unwind with a relaxing afternoon tea. Meet incredible animals up close and enjoy 
-              a memorable day out in nature.
-            </p>
+            {isAutoAccept && pathname === '/product/autoaccept' ? (
+              <p className="description">
+                Enjoy a memorable day out with this experience, combining relaxation, discovery and the chance to do something a little different. Whether you’re looking to explore, unwind or try something new, this is the perfect way to spend your time.
+              </p>
+            ) : (
+              <p className="description">
+                Explore the vast 600-acre expanse of Port Lympne Reserve and its historic landscape,
+                then unwind with a relaxing afternoon tea. Meet incredible animals up close and enjoy 
+                a memorable day out in nature.
+              </p>
+            )}
             <div className="divider"></div>
             <h2 className="section-title">What's included?</h2>
-            <div className="description">
-              <ul>
-                <li>Unforgettable 45-minute Truck Safari covering 600 acres of ancient parkland</li>
-                <li>The unique chance to admire over 900 animal residents across 75 species right here in the UK</li>
-                <li>Afternoon tea inside the Grade II listed Port Lympne Mansion</li>
-              </ul>
-            </div>
+            {isAutoAccept && pathname === '/product/autoaccept' ? (
+              <div className="description">
+                <ul>
+                  <li>A main activity designed to give you an unforgettable experience</li>
+                  <li>The chance to enjoy unique moments you’ll remember for years to come</li>
+                  <li>Additional touches to make the day extra special (such as food, drink, or exclusive access)</li>
+                </ul>
+              </div>
+            ) : (
+              <div className="description">
+                <ul>
+                  <li>Unforgettable 45-minute Truck Safari covering 600 acres of ancient parkland</li>
+                  <li>The unique chance to admire over 900 animal residents across 75 species right here in the UK</li>
+                  <li>Afternoon tea inside the Grade II listed Port Lympne Mansion</li>
+                </ul>
+              </div>
+            )}
 
             <div className="divider"></div>
             <h2 className="section-title">What do I need to know?</h2>
-            <div className="description">
-              <ul>
-                <li>This experience should last around 60 minutes</li>
-                <li>Open from 9:30 am to 5 pm; last entry at 3:30 pm</li>
-                <li>Available Sunday-Friday, year-round</li>
-                <li>All dates are subject to availability</li>
-                <li>Accessibility; The entrance to the park is via a ramped footbridge with designated disabled parking available at the base of the footbridge on hard-standing. The park has an on-call minibus that can transport you to any area required. (Please notify any member of staff if you require assistance and this will be arranged). Wheelchairs are also available for hire at the Gatehouse!</li>
-              </ul>
-            </div>
+            {isAutoAccept && pathname === '/product/autoaccept' ? (
+              <div className="description">
+                <ul>
+                  <li>The core experience lasts around 60 minutes (may vary depending on activity)</li>
+                  <li>Typical opening times: 9:30 am to 5 pm, with last entry around 3:30 pm</li>
+                  <li>Available Sunday–Friday, year-round</li>
+                  <li>All dates are subject to availability</li>
+                  <li>Accessibility: Venues will have support available for guests who may require assistance, with options such as step-free access, designated parking, or equipment hire where possible. Please contact staff on arrival if support is required.</li>
+                </ul>
+              </div>
+            ) : (
+              <div className="description">
+                <ul>
+                  <li>This experience should last around 60 minutes</li>
+                  <li>Open from 9:30 am to 5 pm; last entry at 3:30 pm</li>
+                  <li>Available Sunday-Friday, year-round</li>
+                  <li>All dates are subject to availability</li>
+                  <li>Accessibility; The entrance to the park is via a ramped footbridge with designated disabled parking available at the base of the footbridge on hard-standing. The park has an on-call minibus that can transport you to any area required. (Please notify any member of staff if you require assistance and this will be arranged). Wheelchairs are also available for hire at the Gatehouse!</li>
+                </ul>
+              </div>
+            )}
             {/* Page footer under description */}
             <div className="footer" aria-hidden="true"></div>
           </div>


### PR DESCRIPTION
Add a new product page at `/product/autoaccept` that replicates the auto-accept flow and conditional logic, but displays new, generic product content.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b335948-2b92-46db-80a5-3a2bfcddb2e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6b335948-2b92-46db-80a5-3a2bfcddb2e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

