### PR TITLE
Update product images with url parameters

### DIFF
--- a/src/pages/FutureVersion.jsx
+++ b/src/pages/FutureVersion.jsx
@@ -28,14 +28,11 @@ export default function FutureVersion() {
   const { search, pathname } = useLocation();
   const hasTimeslotParam = new URLSearchParams(search).has('timeslot');
   const isAutoAccept = pathname === '/autoaccept' || pathname === '/product/autoaccept';
-  const isProductAutoAccept = pathname === '/product/autoaccept';
   const params = new URLSearchParams(search);
   const imageParamOrder = ['hotel', 'racing', 'zoo', 'dinner', 'elephant'];
   const selectedImageKey = imageParamOrder.find(k => params.has(k));
-  const autoacceptImageSrc = isProductAutoAccept
-    ? (selectedImageKey
-      ? (selectedImageKey === 'elephant' ? elephant : `/assets/${selectedImageKey}.png`)
-      : elephant)
+  const autoacceptImageSrc = selectedImageKey
+    ? (selectedImageKey === 'elephant' ? elephant : `/assets/${selectedImageKey}.png`)
     : elephant;
 
   useEffect(() => {
@@ -105,7 +102,7 @@ export default function FutureVersion() {
       </div>
 
       <div className="main-image">
-        <img src={isProductAutoAccept ? autoacceptImageSrc : elephant} alt="Giraffes and safari trucks at Port Lympne" onError={(e) => { if (e.currentTarget.src !== elephant) { e.currentTarget.src = elephant; } }} />
+        <img src={isAutoAccept ? autoacceptImageSrc : elephant} alt="Giraffes and safari trucks at Port Lympne" onError={(e) => { if (e.currentTarget.src !== elephant) { e.currentTarget.src = elephant; } }} />
         <div className="carousel-dots" aria-hidden="true">
           <span className="dot active"></span>
           <span className="dot"></span>


### PR DESCRIPTION
Enable dynamic product image display on `/product/autoaccept` via URL query parameters.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1ad05ec-f718-4a03-adfd-c31b6177c3c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d1ad05ec-f718-4a03-adfd-c31b6177c3c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

