### PR TITLE
Update product autoaccept locations and breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs.jsx
@@ -5,6 +5,8 @@ import { PRODUCT_TITLE } from "../constants";
 export default function Breadcrumbs() {
   const location = useLocation();
   const isRequestPage = location.pathname === "/request-to-book";
+  const isProductAutoaccept = location.pathname === "/product/autoaccept";
+  const currentTitle = isProductAutoaccept ? "Unforgettable Experience for Two" : PRODUCT_TITLE;
 
   return (
     <nav className="breadcrumbs" aria-label="Breadcrumb">
@@ -15,13 +17,13 @@ export default function Breadcrumbs() {
       {isRequestPage ? (
         <>
           <span className="crumb">
-            <Link to="/">{PRODUCT_TITLE}</Link>
+            <Link to="/">{currentTitle}</Link>
           </span>
           <span className="separator">{" -> "}</span>
           <span className="crumb current" aria-current="page">Request Availability</span>
         </>
       ) : (
-        <span className="crumb current" aria-current="page">{PRODUCT_TITLE}</span>
+        <span className="crumb current" aria-current="page">{currentTitle}</span>
       )}
     </nav>
   );

--- a/src/components/LocationActionSheet.jsx
+++ b/src/components/LocationActionSheet.jsx
@@ -1,15 +1,16 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 
-const LOCATIONS = [
+const DEFAULT_LOCATIONS = [
   "Port Lympne Kent",
   "Port Lympne Hampshire",
   "Port Lympne Essex",
 ];
 
-export default function LocationActionSheet({ anchorRef, isOpen, onClose, onSelect, selected }) {
+export default function LocationActionSheet({ anchorRef, isOpen, onClose, onSelect, selected, locations }) {
   const panelRef = useRef(null);
   const [isDesktop, setIsDesktop] = useState(false);
   const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
+  const options = Array.isArray(locations) && locations.length > 0 ? locations : DEFAULT_LOCATIONS;
 
   useEffect(() => {
     const mql = window.matchMedia('(min-width: 1024px)');
@@ -67,7 +68,7 @@ export default function LocationActionSheet({ anchorRef, isOpen, onClose, onSele
           </div>
           <div className="booking-body">
             <div role="listbox" aria-label="Choose location" className="location-dropdown" style={{ position: 'static', border: 'none', boxShadow: 'none' }}>
-              {LOCATIONS.map((loc) => (
+              {options.map((loc) => (
                 <button
                   type="button"
                   key={loc}
@@ -88,7 +89,7 @@ export default function LocationActionSheet({ anchorRef, isOpen, onClose, onSele
 
   return (
     <div ref={panelRef} className="location-popover" style={{ top: `${position.top}px`, left: `${position.left}px`, width: `${position.width}px` }} role="listbox" aria-label="Choose location">
-      {LOCATIONS.map((loc) => (
+      {options.map((loc) => (
         <button
           type="button"
           key={loc}

--- a/src/pages/FutureVersion.jsx
+++ b/src/pages/FutureVersion.jsx
@@ -315,6 +315,7 @@ export default function FutureVersion() {
         onClose={() => setIsLocationOpen(false)}
         onSelect={(loc) => setSelectedLocation(loc)}
         selected={selectedLocation}
+        locations={pathname === '/product/autoaccept' ? ['London', 'Manchester', 'Glasgow', 'Bristol'] : undefined}
       />
 
       {isCalendarOpen && (


### PR DESCRIPTION
Update location dropdown options and breadcrumb title for the `/product/autoaccept` page to match specific product requirements.

The changes ensure that the `/product/autoaccept` flow displays a custom list of locations ('London', 'Manchester', 'Glasgow', 'Bristol') and a specific product name ('Unforgettable Experience for Two') in the breadcrumbs, without affecting the default behavior on other pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-216d69b1-bd6e-4a71-9cc3-d001060e5e86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-216d69b1-bd6e-4a71-9cc3-d001060e5e86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

