### PR TITLE
Update product details and confirmation text

### DIFF
--- a/src/components/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs.jsx
@@ -5,8 +5,8 @@ import { PRODUCT_TITLE } from "../constants";
 export default function Breadcrumbs() {
   const location = useLocation();
   const isRequestPage = location.pathname === "/request-to-book";
-  const isProductAutoaccept = location.pathname === "/product/autoaccept";
-  const currentTitle = isProductAutoaccept ? "Unforgettable Experience for Two" : PRODUCT_TITLE;
+  const isProductExperience = location.pathname === "/product" || location.pathname === "/product/autoaccept";
+  const currentTitle = isProductExperience ? "Unforgettable Experience for Two" : PRODUCT_TITLE;
 
   return (
     <nav className="breadcrumbs" aria-label="Breadcrumb">

--- a/src/components/CalendarPopover.jsx
+++ b/src/components/CalendarPopover.jsx
@@ -9,6 +9,8 @@ export default function CalendarPopover({ anchorRef, onClose, selectedLocation, 
   const { pathname, search } = useLocation();
   const isAutoAccept = pathname === '/autoaccept' || pathname === '/product/autoaccept';
   const isProductAutoAccept = pathname === '/product/autoaccept';
+  const isProductJourney = pathname === '/product';
+  const usesNewExperienceContent = isProductJourney || isProductAutoAccept;
   const hasTimeslotParam = new URLSearchParams(search).has('timeslot');
 
   const [currentMonth, setCurrentMonth] = useState(() => {
@@ -120,7 +122,7 @@ export default function CalendarPopover({ anchorRef, onClose, selectedLocation, 
           time: hasTimeslotParam ? getSelectedTimeLabel() : undefined,
         }];
         const draft = {
-          location: selectedLocation || (isProductAutoAccept ? 'Multiple venues across the UK' : 'Port Lympne Kent'),
+          location: selectedLocation || (usesNewExperienceContent ? 'Multiple venues across the UK' : 'Port Lympne Kent'),
           dates,
           timestamp: new Date().toISOString(),
           source: 'autoaccept',
@@ -174,7 +176,7 @@ export default function CalendarPopover({ anchorRef, onClose, selectedLocation, 
         time: (isAutoAccept && hasTimeslotParam) ? getSelectedTimeLabel() : undefined,
       }));
       const draft = {
-        location: selectedLocation || (isProductAutoAccept ? 'Multiple venues across the UK' : 'Port Lympne Kent'),
+        location: selectedLocation || (usesNewExperienceContent ? 'Multiple venues across the UK' : 'Port Lympne Kent'),
         dates,
         timestamp: new Date().toISOString(),
         source: isAutoAccept ? 'autoaccept' : 'regular',
@@ -262,7 +264,7 @@ export default function CalendarPopover({ anchorRef, onClose, selectedLocation, 
         time: (isAutoAccept && hasTimeslotParam) ? getSelectedTimeLabel() : undefined,
       }));
       const draft = {
-        location: selectedLocation || (isProductAutoAccept ? 'Multiple venues across the UK' : "Port Lympne Kent"),
+        location: selectedLocation || (usesNewExperienceContent ? 'Multiple venues across the UK' : "Port Lympne Kent"),
         dates,
         timestamp: new Date().toISOString(),
         source: isAutoAccept ? 'autoaccept' : 'regular',
@@ -284,7 +286,7 @@ export default function CalendarPopover({ anchorRef, onClose, selectedLocation, 
         time: (isAutoAccept && hasTimeslotParam) ? getSelectedTimeLabel() : undefined,
       }));
       const draft = {
-        location: selectedLocation || (isProductAutoAccept ? 'Multiple venues across the UK' : "Port Lympne Kent"),
+        location: selectedLocation || (usesNewExperienceContent ? 'Multiple venues across the UK' : "Port Lympne Kent"),
         dates,
         timestamp: new Date().toISOString(),
         source: isAutoAccept ? 'autoaccept' : 'regular',

--- a/src/pages/Confirmation.jsx
+++ b/src/pages/Confirmation.jsx
@@ -35,9 +35,9 @@ export default function Confirmation() {
           <div className="confetti-icon" aria-hidden>🎉</div>
           <h1 className="title">{isAutoAcceptJourney ? 'Booking successful' : 'Request sent'}</h1>
           <p className="confirmation-message">
-            {isAutoAcceptJourney
-              ? 'Your booking with the experience provider is confirmed. Please enjoy your experience.'
-              : "Your booking request has been sent to Port Lympne. Expect a response confirming or rejecting the dates in the next 24 hours."}
+              {isAutoAcceptJourney
+                ? 'Your booking with the experience provider is confirmed. Please enjoy your experience.'
+                : "Your booking request has been sent to the experience provider. Expect a response confirming or rejecting the dates in the next 24 hours."}
           </p>
           <div className="request-id">Request ID: 1234567890</div>
         </div>

--- a/src/pages/FutureVersion.jsx
+++ b/src/pages/FutureVersion.jsx
@@ -30,6 +30,7 @@ export default function FutureVersion() {
   const isAutoAccept = pathname === '/autoaccept' || pathname === '/product/autoaccept';
   const isProductAutoAccept = pathname === '/product/autoaccept';
   const isProductJourney = pathname === '/product';
+  const usesNewExperienceContent = isProductJourney || isProductAutoAccept;
   const headerImageSrc = (() => {
     if (isProductAutoAccept || isProductJourney) {
       return hasTimeslotParam ? '/assets/dinner.jpg' : '/assets/zoo.jpg';
@@ -107,142 +108,142 @@ export default function FutureVersion() {
         </div>
       </div>
 
-      <div className="main-image">
-        <img src={headerImageSrc} alt="Giraffes and safari trucks at Port Lympne" />
-        <div className="carousel-dots" aria-hidden="true">
-          <span className="dot active"></span>
-          <span className="dot"></span>
-          <span className="dot"></span>
-          <span className="dot"></span>
-          <span className="dot"></span>
+        <div className="main-image">
+          <img src={headerImageSrc} alt="Guests enjoying an unforgettable experience" />
+          <div className="carousel-dots" aria-hidden="true">
+            <span className="dot active"></span>
+            <span className="dot"></span>
+            <span className="dot"></span>
+            <span className="dot"></span>
+            <span className="dot"></span>
+          </div>
         </div>
-      </div>
 
-      <div className="content">
-        <Breadcrumbs />
-      </div>
+        <div className="content">
+          <Breadcrumbs />
+        </div>
 
-      <div className="content">
-        <div className="product-layout">
-          <div className="product-main">
-            <div className="product-id">118107722</div>
-            <h1 className="title">{isAutoAccept && pathname === '/product/autoaccept' ? 'Unforgettable Experience for Two' : PRODUCT_TITLE}</h1>
-            <div className="location">
-              <span className="chip-icon chip-icon--pin" aria-hidden="true"></span> {isAutoAccept && pathname === '/product/autoaccept' ? 'Multiple venues across the UK' : 'The Aspinall Foundation, Nr Ashford Kent, Lympne Hythe, CT21 4PD'}
-            </div>
-            <div className="validity">
-              <span className="use-by">Use by 19th Aug 2026</span>
-              <span className="extend" role="button" tabIndex={0}>Extend</span>
-            </div>
-            <div className="flexibility">
-              <img src="/assets/flexible_exchange.png" alt="" aria-hidden="true" className="flex-icon-img" />
-              <span className="flexible-text">Fully Flexible</span>
-            </div>
+        <div className="content">
+          <div className="product-layout">
+            <div className="product-main">
+              <div className="product-id">118107722</div>
+              <h1 className="title">{usesNewExperienceContent ? 'Unforgettable Experience for Two' : PRODUCT_TITLE}</h1>
+              <div className="location">
+                <span className="chip-icon chip-icon--pin" aria-hidden="true"></span> {usesNewExperienceContent ? 'Multiple venues across the UK' : 'The Aspinall Foundation, Nr Ashford Kent, Lympne Hythe, CT21 4PD'}
+              </div>
+              <div className="validity">
+                <span className="use-by">Use by 19th Aug 2026</span>
+                <span className="extend" role="button" tabIndex={0}>Extend</span>
+              </div>
+              <div className="flexibility">
+                <img src="/assets/flexible_exchange.png" alt="" aria-hidden="true" className="flex-icon-img" />
+                <span className="flexible-text">Fully Flexible</span>
+              </div>
 
-            {/* Mobile inline controls with divider above and below; hide entire section on desktop */}
-            <div className="future-inline-section">
-              <div className="divider"></div>
-              <div className="future-inline-controls" aria-label="Choose options">
-                {/* Location pill (full width) */}
-                <button
-                  type="button"
-                  className="chip-button chip-button--full"
-                  ref={locationChipInlineRef}
-                  onClick={() => setIsLocationOpen(true)}
-                  aria-haspopup="dialog listbox"
-                  aria-expanded={isLocationOpen}
-                >
-                  <span className="chip-icon chip-icon--pin" aria-hidden="true"></span>
-                  <span>{selectedLocation ? selectedLocation : "Choose location"}</span>
-                </button>
-
-                {/* Dates pill */}
-                <button
-                  type="button"
-                  className={`chip-button${(isAutoAccept || !shouldShowTimeslotSelector) ? ' chip-button--full' : ''}`}
-                  ref={ctaMobileRef}
-                  onClick={() => setIsCalendarOpen(true)}
-                  aria-haspopup="dialog"
-                  aria-expanded={isCalendarOpen}
-                >
-                  <span className="chip-icon chip-icon--calendar" aria-hidden="true"></span>
-                  <span>{selectedDateTimeLabel ? selectedDateTimeLabel : 'Select date'}</span>
-                </button>
-
-                {/* Times pill (hidden on autoaccept) */}
-                {shouldShowTimeslotSelector && (
+              {/* Mobile inline controls with divider above and below; hide entire section on desktop */}
+              <div className="future-inline-section">
+                <div className="divider"></div>
+                <div className="future-inline-controls" aria-label="Choose options">
+                  {/* Location pill (full width) */}
                   <button
                     type="button"
-                    className="chip-button"
-                    ref={timeslotMobileRef}
-                    onClick={() => setIsTimeslotOpen(true)}
+                    className="chip-button chip-button--full"
+                    ref={locationChipInlineRef}
+                    onClick={() => setIsLocationOpen(true)}
+                    aria-haspopup="dialog listbox"
+                    aria-expanded={isLocationOpen}
                   >
-                    <span className="chip-icon chip-icon--clock" aria-hidden="true"></span>
-                    <span>Select time</span>
+                    <span className="chip-icon chip-icon--pin" aria-hidden="true"></span>
+                    <span>{selectedLocation ? selectedLocation : "Choose location"}</span>
                   </button>
-                )}
+
+                  {/* Dates pill */}
+                  <button
+                    type="button"
+                    className={`chip-button${(isAutoAccept || !shouldShowTimeslotSelector) ? ' chip-button--full' : ''}`}
+                    ref={ctaMobileRef}
+                    onClick={() => setIsCalendarOpen(true)}
+                    aria-haspopup="dialog"
+                    aria-expanded={isCalendarOpen}
+                  >
+                    <span className="chip-icon chip-icon--calendar" aria-hidden="true"></span>
+                    <span>{selectedDateTimeLabel ? selectedDateTimeLabel : 'Select date'}</span>
+                  </button>
+
+                  {/* Times pill (hidden on autoaccept) */}
+                  {shouldShowTimeslotSelector && (
+                    <button
+                      type="button"
+                      className="chip-button"
+                      ref={timeslotMobileRef}
+                      onClick={() => setIsTimeslotOpen(true)}
+                    >
+                      <span className="chip-icon chip-icon--clock" aria-hidden="true"></span>
+                      <span>Select time</span>
+                    </button>
+                  )}
+                </div>
+                <div className="divider"></div>
               </div>
+
+              <h2 className="section-title">About the experience</h2>
+              {usesNewExperienceContent ? (
+                <p className="description">
+                  Enjoy a memorable day out with this experience, combining relaxation, discovery and the chance to do something a little different. Whether you're looking to explore, unwind or try something new, this is the perfect way to spend your time.
+                </p>
+              ) : (
+                <p className="description">
+                  Explore the vast 600-acre expanse of Port Lympne Reserve and its historic landscape,
+                  then unwind with a relaxing afternoon tea. Meet incredible animals up close and enjoy 
+                  a memorable day out in nature.
+                </p>
+              )}
               <div className="divider"></div>
+              <h2 className="section-title">What's included?</h2>
+              {usesNewExperienceContent ? (
+                <div className="description">
+                  <ul>
+                    <li>A main activity designed to give you an unforgettable experience</li>
+                    <li>The chance to enjoy unique moments you'll remember for years to come</li>
+                    <li>Additional touches to make the day extra special (such as food, drink, or exclusive access)</li>
+                  </ul>
+                </div>
+              ) : (
+                <div className="description">
+                  <ul>
+                    <li>Unforgettable 45-minute Truck Safari covering 600 acres of ancient parkland</li>
+                    <li>The unique chance to admire over 900 animal residents across 75 species right here in the UK</li>
+                    <li>Afternoon tea inside the Grade II listed Port Lympne Mansion</li>
+                  </ul>
+                </div>
+              )}
+
+              <div className="divider"></div>
+              <h2 className="section-title">What do I need to know?</h2>
+              {usesNewExperienceContent ? (
+                <div className="description">
+                  <ul>
+                    <li>The core experience lasts around 60 minutes (may vary depending on activity)</li>
+                    <li>Typical opening times: 9:30 am to 5 pm, with last entry around 3:30 pm</li>
+                    <li>Available Sunday-Friday, year-round</li>
+                    <li>All dates are subject to availability</li>
+                    <li>Accessibility: Venues will have support available for guests who may require assistance, with options such as step-free access, designated parking, or equipment hire where possible. Please contact staff on arrival if support is required.</li>
+                  </ul>
+                </div>
+              ) : (
+                <div className="description">
+                  <ul>
+                    <li>This experience should last around 60 minutes</li>
+                    <li>Open from 9:30 am to 5 pm; last entry at 3:30 pm</li>
+                    <li>Available Sunday-Friday, year-round</li>
+                    <li>All dates are subject to availability</li>
+                    <li>Accessibility; The entrance to the park is via a ramped footbridge with designated disabled parking available at the base of the footbridge on hard-standing. The park has an on-call minibus that can transport you to any area required. (Please notify any member of staff if you require assistance and this will be arranged). Wheelchairs are also available for hire at the Gatehouse!</li>
+                  </ul>
+                </div>
+              )}
+              {/* Page footer under description */}
+              <div className="footer" aria-hidden="true"></div>
             </div>
-
-            <h2 className="section-title">About the experience</h2>
-            {isAutoAccept && pathname === '/product/autoaccept' ? (
-              <p className="description">
-                Enjoy a memorable day out with this experience, combining relaxation, discovery and the chance to do something a little different. Whether you’re looking to explore, unwind or try something new, this is the perfect way to spend your time.
-              </p>
-            ) : (
-              <p className="description">
-                Explore the vast 600-acre expanse of Port Lympne Reserve and its historic landscape,
-                then unwind with a relaxing afternoon tea. Meet incredible animals up close and enjoy 
-                a memorable day out in nature.
-              </p>
-            )}
-            <div className="divider"></div>
-            <h2 className="section-title">What's included?</h2>
-            {isAutoAccept && pathname === '/product/autoaccept' ? (
-              <div className="description">
-                <ul>
-                  <li>A main activity designed to give you an unforgettable experience</li>
-                  <li>The chance to enjoy unique moments you’ll remember for years to come</li>
-                  <li>Additional touches to make the day extra special (such as food, drink, or exclusive access)</li>
-                </ul>
-              </div>
-            ) : (
-              <div className="description">
-                <ul>
-                  <li>Unforgettable 45-minute Truck Safari covering 600 acres of ancient parkland</li>
-                  <li>The unique chance to admire over 900 animal residents across 75 species right here in the UK</li>
-                  <li>Afternoon tea inside the Grade II listed Port Lympne Mansion</li>
-                </ul>
-              </div>
-            )}
-
-            <div className="divider"></div>
-            <h2 className="section-title">What do I need to know?</h2>
-            {isAutoAccept && pathname === '/product/autoaccept' ? (
-              <div className="description">
-                <ul>
-                  <li>The core experience lasts around 60 minutes (may vary depending on activity)</li>
-                  <li>Typical opening times: 9:30 am to 5 pm, with last entry around 3:30 pm</li>
-                  <li>Available Sunday–Friday, year-round</li>
-                  <li>All dates are subject to availability</li>
-                  <li>Accessibility: Venues will have support available for guests who may require assistance, with options such as step-free access, designated parking, or equipment hire where possible. Please contact staff on arrival if support is required.</li>
-                </ul>
-              </div>
-            ) : (
-              <div className="description">
-                <ul>
-                  <li>This experience should last around 60 minutes</li>
-                  <li>Open from 9:30 am to 5 pm; last entry at 3:30 pm</li>
-                  <li>Available Sunday-Friday, year-round</li>
-                  <li>All dates are subject to availability</li>
-                  <li>Accessibility; The entrance to the park is via a ramped footbridge with designated disabled parking available at the base of the footbridge on hard-standing. The park has an on-call minibus that can transport you to any area required. (Please notify any member of staff if you require assistance and this will be arranged). Wheelchairs are also available for hire at the Gatehouse!</li>
-                </ul>
-              </div>
-            )}
-            {/* Page footer under description */}
-            <div className="footer" aria-hidden="true"></div>
-          </div>
 
             {/* Desktop: remade container with Date, Location and Check availability */}
             <aside className="cta-card future-cta-card" aria-label="Availability actions">
@@ -301,8 +302,8 @@ export default function FutureVersion() {
                 </button>
               </div>
             </aside>
+          </div>
         </div>
-      </div>
 
       {/* Mobile sticky CTA - always enabled for both flows */}
       <div className="ctaBar">
@@ -318,14 +319,14 @@ export default function FutureVersion() {
       </div>
 
       {/* Overlays/Popovers */}
-      <LocationActionSheet
-        anchorRef={isDesktop ? locationChipCardRef : locationChipInlineRef}
-        isOpen={isLocationOpen}
-        onClose={() => setIsLocationOpen(false)}
-        onSelect={(loc) => setSelectedLocation(loc)}
-        selected={selectedLocation}
-        locations={pathname === '/product/autoaccept' ? ['London', 'Manchester', 'Glasgow', 'Bristol'] : undefined}
-      />
+        <LocationActionSheet
+          anchorRef={isDesktop ? locationChipCardRef : locationChipInlineRef}
+          isOpen={isLocationOpen}
+          onClose={() => setIsLocationOpen(false)}
+          onSelect={(loc) => setSelectedLocation(loc)}
+          selected={selectedLocation}
+          locations={usesNewExperienceContent ? ['London', 'Manchester', 'Glasgow', 'Bristol'] : undefined}
+        />
 
       {isCalendarOpen && (
         <CalendarPopover 


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-84541f2e-c77a-4092-9458-67e991b43e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-84541f2e-c77a-4092-9458-67e991b43e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generalizes product pages to use a generic experience title/location for `/product` and `/product/autoaccept`, updates confirmation copy, and aligns Calendar draft location persistence and location picker options accordingly.
> 
> - **Frontend**
>   - **Product pages (`src/pages/FutureVersion.jsx`)**:
>     - Use generic title `"Unforgettable Experience for Two"` and location `"Multiple venues across the UK"` when on `/product` or `/product/autoaccept`.
>     - Update header image alt text and switch content sections (About/What's included/Need to know) to generic copy under the same condition.
>     - LocationActionSheet now shows predefined city list only for the new experience content paths.
>   - **Breadcrumbs (`src/components/Breadcrumbs.jsx`)**:
>     - Treat `/product` and `/product/autoaccept` as product experience; breadcrumb title reflects the generic experience title.
>   - **Calendar (`src/components/CalendarPopover.jsx`)**:
>     - Introduce `usesNewExperienceContent`; default draft `location` to `"Multiple venues across the UK"` for product journeys and autoaccept.
>     - Apply this default in all draft persistence points (single-date select, multi-date effects, proceed/checkout paths).
>   - **Confirmation (`src/pages/Confirmation.jsx`)**:
>     - Non-autoaccept message now references "the experience provider" instead of a specific venue.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca105192d3d3afe4a637d7bc90cfb83d486db252. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->