### PR TITLE
Update product page date and timeslot selection

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1683,6 +1683,7 @@ textarea.form-input,
 }
 
 .timeslot-popover {
+  position: absolute;
   display: flex;
   flex-direction: column;
   overflow: visible;

--- a/src/App.css
+++ b/src/App.css
@@ -610,11 +610,6 @@ body {
   display: flex;
   flex-direction: column;
   gap: 16px;
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow-y: auto;
-  max-height: 100%;
-  padding-right: 4px; /* room for scrollbar */
 }
 
 .timeslot-sections {
@@ -1690,7 +1685,7 @@ textarea.form-input,
 .timeslot-popover {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: visible;
 }
 
 /* Ensure calendar fully expands inside action sheets */

--- a/src/components/TimeslotModal.jsx
+++ b/src/components/TimeslotModal.jsx
@@ -230,12 +230,6 @@ export default function TimeslotModal({ isOpen, onClose, anchorRef }) {
   }
 
   const showGridLayout = isDesktop && dates.length > 1;
-  const gridRows = showGridLayout ? Math.ceil(dates.length / 2) : Math.max(dates.length, 1);
-  const estimatedHeaderHeight = 112;
-  const estimatedCardHeight = 240;
-  const dynamicMaxHeight = isDesktop
-    ? Math.min(position.maxHeight || 720, estimatedHeaderHeight + gridRows * estimatedCardHeight)
-    : undefined;
 
   const content = (
     <>
@@ -298,8 +292,7 @@ export default function TimeslotModal({ isOpen, onClose, anchorRef }) {
       style={{
         top: `${position.top || 120}px`,
         left: `${position.left || 24}px`,
-        width: `${position.width || 520}px`,
-        maxHeight: dynamicMaxHeight ? `${dynamicMaxHeight}px` : undefined
+        width: `${position.width || 520}px`
       }}
       role="dialog"
       aria-modal="false"

--- a/src/components/TimeslotModal.jsx
+++ b/src/components/TimeslotModal.jsx
@@ -9,7 +9,7 @@ export default function TimeslotModal({ isOpen, onClose, anchorRef }) {
   const [selectedTimesByIso, setSelectedTimesByIso] = useState({}); // { [iso]: 'HH:MM' }
   const popoverRef = useRef(null);
   const [isDesktop, setIsDesktop] = useState(false);
-  const [position, setPosition] = useState({ top: 0, left: 0, width: 0, maxHeight: 0 });
+  const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
 
   function formatHuman(date) {
     const day = date.getDate();
@@ -112,28 +112,30 @@ export default function TimeslotModal({ isOpen, onClose, anchorRef }) {
     function updatePosition() {
       const RIGHT_MARGIN = 48;
       const LEFT_MARGIN = 24;
-      const BOTTOM_MARGIN = 128; // leave space for CTA area
       const MAX_WIDTH = 700;
       const MIN_WIDTH = 420;
       const winW = typeof window !== 'undefined' ? window.innerWidth : 1024;
-      const winH = typeof window !== 'undefined' ? window.innerHeight : 768;
+      const scrollX = typeof window !== 'undefined' ? window.scrollX || window.pageXOffset || 0 : 0;
+      const scrollY = typeof window !== 'undefined' ? window.scrollY || window.pageYOffset || 0 : 0;
+
       if (!anchorRef?.current) {
         const width = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, Math.floor(winW * 0.8)));
-        const left = Math.max(LEFT_MARGIN, winW - width - RIGHT_MARGIN);
-        const desiredTop = 120;
-        const maxHeight = Math.max(240, winH - desiredTop - BOTTOM_MARGIN);
-        setPosition({ top: desiredTop, left, width, maxHeight });
+        const left = scrollX + Math.max(LEFT_MARGIN, winW - width - RIGHT_MARGIN);
+        const top = scrollY + 120;
+        setPosition({ top, left, width });
         return;
       }
+
       const rect = anchorRef.current.getBoundingClientRect();
-      const desiredTop = rect.bottom + 8; // small offset
+      const viewportTop = rect.bottom + 8; // relative to viewport
       const availableRight = winW - rect.left - RIGHT_MARGIN;
       const availableLeft = rect.right - LEFT_MARGIN;
       const candidate = Math.max(availableLeft, availableRight);
       const width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, candidate));
-      const left = Math.max(LEFT_MARGIN, rect.right - width);
-      const maxHeight = Math.max(240, winH - desiredTop - BOTTOM_MARGIN);
-      setPosition({ top: desiredTop, left, width, maxHeight });
+      const leftViewport = Math.max(LEFT_MARGIN, rect.right - width);
+      const left = scrollX + leftViewport;
+      const top = scrollY + Math.max(24, viewportTop);
+      setPosition({ top, left, width });
     }
 
     updatePosition();


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-3a2227cf-e093-42f2-bc70-551efa8c8bb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a2227cf-e093-42f2-bc70-551efa8c8bb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines desktop timeslot popover positioning (scroll-aware, unconstrained height) and updates product page chips to reflect selected date count/labels with minor copy tweaks.
> 
> - **UI/UX**:
>   - **Timeslot popover (desktop)**: Reworked positioning to be scroll-aware (`scrollX/scrollY`), switched to absolute positioning, and removed max-height constraints and related logic in `TimeslotModal.jsx` and `App.css`.
>   - **Date/time chips**: `FutureVersion.jsx` now tracks `selectedDatesCount` and dynamically labels date chips (mobile/desktop) with either the selected date/time (autoaccept) or a count (product journey).
>   - Minor copy change: timeslot chip text from `Select time` to `time`.
> - **Styling**:
>   - Adjusted `.timeslot-modal-content` and `.timeslot-popover` to allow overflow visibility; simplified container constraints in `App.css`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02e976a9df23ede5e578b151397e8aec95f1a4ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->